### PR TITLE
【UI】organisms/Tab の作成

### DIFF
--- a/src/components/organisms/Tab.stories.tsx
+++ b/src/components/organisms/Tab.stories.tsx
@@ -1,0 +1,31 @@
+import { Tab } from "./Tab"
+
+import type { Meta, StoryObj } from "@storybook/react"
+
+const meta: Meta<typeof Tab> = {
+  title: "Organisms/Tab",
+  component: Tab,
+  tags: ["autodocs"],
+}
+
+export default meta
+type Story = StoryObj<typeof Tab>
+
+export const Normal: Story = {
+  args: {
+    tabItems: [
+      {
+        label: "ラベル1",
+        children: <div>aaa</div>,
+      },
+      {
+        label: "ラベル2",
+        children: <div>bbb</div>,
+      },
+      {
+        label: "ラベル3",
+        children: <div>ccc</div>,
+      },
+    ],
+  },
+}

--- a/src/components/organisms/Tab.stories.tsx
+++ b/src/components/organisms/Tab.stories.tsx
@@ -1,4 +1,5 @@
 import { Tab } from "./Tab"
+import SampleTabContent from "./_SampleTabContent"
 
 import type { Meta, StoryObj } from "@storybook/react"
 
@@ -11,20 +12,35 @@ const meta: Meta<typeof Tab> = {
 export default meta
 type Story = StoryObj<typeof Tab>
 
-export const Normal: Story = {
+export const three_tabs: Story = {
   args: {
     tabItems: [
       {
-        label: "ラベル1",
-        children: <div>aaa</div>,
+        label: "すべて",
+        component: <SampleTabContent bgColor="Mauve-10" />,
       },
       {
-        label: "ラベル2",
-        children: <div>bbb</div>,
+        label: "シェフ",
+        component: <div>コンポーネント2</div>,
       },
       {
-        label: "ラベル3",
-        children: <div>ccc</div>,
+        label: "レシピ",
+        component: <SampleTabContent bgColor="Tomato-12" />,
+      },
+    ],
+  },
+}
+
+export const two_tabs: Story = {
+  args: {
+    tabItems: [
+      {
+        label: "作り方",
+        component: <SampleTabContent bgColor="Mauve-10" />,
+      },
+      {
+        label: "材料",
+        component: <SampleTabContent bgColor="Tomato-12" />,
       },
     ],
   },

--- a/src/components/organisms/Tab.tsx
+++ b/src/components/organisms/Tab.tsx
@@ -1,0 +1,89 @@
+"use client"
+
+import { createContext, useMemo, useState, useContext, FC, ReactNode, ReactElement } from "react"
+
+type TabKey = string
+type TabLabel = string
+
+type TabLabelProps = {
+  defaultKey: TabKey
+  children: ReactElement<TabContentsProps>[]
+}
+
+type TabLabelItem = {
+  tabKey: TabKey
+  label: TabLabel
+}
+
+type TabContextState = {
+  activeKey: TabKey
+}
+
+const TabContext = createContext<TabContextState>({
+  activeKey: "",
+})
+
+export const TabLabel: FC<TabLabelProps> = ({ defaultKey, children }) => {
+  const [activeKey, setActiveKey] = useState(defaultKey)
+
+  const tabLabelItems = useMemo<TabLabelItem[]>(() => {
+    const headerArray: TabLabelItem[] = []
+
+    console.log("tanaka children", children)
+
+    console.log("tanaka Array.isArray(children)", Array.isArray(children))
+
+    children.forEach((c) => {
+      headerArray.push({
+        tabKey: c.props.tabKey,
+        label: c.props.label,
+      })
+    })
+
+    return headerArray
+  }, [children])
+
+  return (
+    <TabContext.Provider value={{ activeKey }}>
+      <ul className="flex">
+        {tabLabelItems.map(({ tabKey, label }) => {
+          return (
+            <li className="px-4" key={tabKey}>
+              <button className="" onClick={() => setActiveKey(tabKey)}>
+                {label}
+              </button>
+            </li>
+          )
+        })}
+      </ul>
+      {children}
+    </TabContext.Provider>
+  )
+}
+
+type TabContentsProps = {
+  tabKey: TabKey
+  label: TabLabel
+  children: ReactNode
+}
+
+export const TabContents: FC<TabContentsProps> = ({ tabKey, children }) => {
+  const { activeKey } = useContext(TabContext)
+  return activeKey === tabKey ? <div>{children}</div> : null
+}
+
+type TabProps = {
+  tabItems: { label: string; children: ReactNode }[]
+}
+
+export const Tab = ({ tabItems }: TabProps) => {
+  return (
+    <TabLabel defaultKey="item1">
+      {tabItems.map((item, index) => (
+        <TabContents tabKey={`item${index + 1}`} label={item.label} key={index}>
+          {item.children}
+        </TabContents>
+      ))}
+    </TabLabel>
+  )
+}

--- a/src/components/organisms/Tab.tsx
+++ b/src/components/organisms/Tab.tsx
@@ -1,89 +1,37 @@
 "use client"
 
-import { createContext, useMemo, useState, useContext, FC, ReactNode, ReactElement } from "react"
+import { useState, ReactNode } from "react"
 
-type TabKey = string
-type TabLabel = string
-
-type TabLabelProps = {
-  defaultKey: TabKey
-  children: ReactElement<TabContentsProps>[]
+type TabProps = {
+  tabItems: { label: string; component: ReactNode }[]
 }
 
-type TabLabelItem = {
-  tabKey: TabKey
-  label: TabLabel
-}
-
-type TabContextState = {
-  activeKey: TabKey
-}
-
-const TabContext = createContext<TabContextState>({
-  activeKey: "",
-})
-
-export const TabLabel: FC<TabLabelProps> = ({ defaultKey, children }) => {
-  const [activeKey, setActiveKey] = useState(defaultKey)
-
-  const tabLabelItems = useMemo<TabLabelItem[]>(() => {
-    const headerArray: TabLabelItem[] = []
-
-    console.log("tanaka children", children)
-
-    console.log("tanaka Array.isArray(children)", Array.isArray(children))
-
-    children.forEach((c) => {
-      headerArray.push({
-        tabKey: c.props.tabKey,
-        label: c.props.label,
-      })
-    })
-
-    return headerArray
-  }, [children])
+export const Tab = ({ tabItems }: TabProps) => {
+  const [activeTab, setActiveTab] = useState<string>("item1")
 
   return (
-    <TabContext.Provider value={{ activeKey }}>
+    <div className="max-w-[480px] w-full">
       <ul className="flex">
-        {tabLabelItems.map(({ tabKey, label }) => {
+        {tabItems.map(({ label }, index) => {
           return (
-            <li className="px-4" key={tabKey}>
-              <button className="" onClick={() => setActiveKey(tabKey)}>
+            <li className="w-full" key={`item${index + 1}`}>
+              <button
+                className={[
+                  "w-full h-10 text-fs16 text-Mauve-12 text-center font-bold",
+                  activeTab === `item${index + 1}` && "border-b-2 border-0 border-Mauve-12",
+                ].join(" ")}
+                onClick={() => setActiveTab(`item${index + 1}`)}
+              >
                 {label}
               </button>
             </li>
           )
         })}
       </ul>
-      {children}
-    </TabContext.Provider>
-  )
-}
 
-type TabContentsProps = {
-  tabKey: TabKey
-  label: TabLabel
-  children: ReactNode
-}
-
-export const TabContents: FC<TabContentsProps> = ({ tabKey, children }) => {
-  const { activeKey } = useContext(TabContext)
-  return activeKey === tabKey ? <div>{children}</div> : null
-}
-
-type TabProps = {
-  tabItems: { label: string; children: ReactNode }[]
-}
-
-export const Tab = ({ tabItems }: TabProps) => {
-  return (
-    <TabLabel defaultKey="item1">
-      {tabItems.map((item, index) => (
-        <TabContents tabKey={`item${index + 1}`} label={item.label} key={index}>
-          {item.children}
-        </TabContents>
-      ))}
-    </TabLabel>
+      {tabItems.map(({ component }, index) => {
+        return activeTab === `item${index + 1}` ? component : null
+      })}
+    </div>
   )
 }

--- a/src/components/organisms/_SampleTabContent.tsx
+++ b/src/components/organisms/_SampleTabContent.tsx
@@ -1,0 +1,27 @@
+/**
+ * TabコンポーネントのStorybookの確認用
+ */
+
+type Props = {
+  bgColor: string
+}
+
+const SampleTabContent = (props: Props) => {
+  return (
+    <div className={`w-full h-96 bg-${props.bgColor}`}>
+      サンプルのコンポーネントです
+      <br />
+      サンプルのコンポーネントです
+      <br />
+      サンプルのコンポーネントです
+      <br />
+      サンプルのコンポーネントです
+      <br />
+      サンプルのコンポーネントです
+      <br />
+      サンプルのコンポーネントです
+    </div>
+  )
+}
+
+export default SampleTabContent


### PR DESCRIPTION
## コンポーネント
https://www.notion.so/df3dfc22003c4516a050a7c6f3c78e3d?pvs=4


## 説明
コンポーネントの粒度的にatomsではなくorganismsにしました 🙇 

いったん、下記のような配列形式でpropsを渡すとタブ切り替えのUIができあがるように実装しています。
タブの中身の部分アンマウントするのが問題になりそうだったら後で修正必要かも？？
使用詰まってきたら別の仕様で作り直す必要あるかも？？


```
tabItems: [
      {
        label: "ラベル1",
        children: コンポーネント1,
      },
      {
        label: "ラベル2",
        children: コンポーネント2,
      },
      {
        label: "ラベル3",
        children: コンポーネント3,
      },
    ],
```