### PR TITLE
Feature/refactoring/font size  tanaka

### DIFF
--- a/src/components/atoms/FavoriteCount/FavoriteCount.tsx
+++ b/src/components/atoms/FavoriteCount/FavoriteCount.tsx
@@ -8,7 +8,7 @@ export const FavoriteCount = (props: FavoriteCountProps) => {
   return (
     <div className="absolute right-2 top-2 flex rounded-2xl bg-Mauve-alpha-10 bg-opacity-50 p-[6px]">
       <Image src="assets/icons/heart.svg" alt="お気に入り数" width={14} height={14} />
-      <p className="ml-1 font-inter text-fs14 leading-none text-Mauve-01">{props.count.toLocaleString()}</p>
+      <p className="ml-1 font-inter text-sm leading-none text-Mauve-01">{props.count.toLocaleString()}</p>
     </div>
   )
 }

--- a/src/components/atoms/IngredientListItem/IngredientListItem.tsx
+++ b/src/components/atoms/IngredientListItem/IngredientListItem.tsx
@@ -32,7 +32,7 @@ export const IngredientListItem = ({
     <li className="flex h-[49px] max-w-[480px] items-center justify-between px-4 py-2">
       <div>
         <h3 className="text-fs14 leading-[17px] text-Mauve-12">{name}</h3>
-        {description && <p className="mt-1 text-fs10 leading-[12px] text-Mauve-10">{description}</p>}
+        {description && <p className=" text-xs mt-1 text-Mauve-10">{description}</p>}
       </div>
       {isUseCartButton && (
         <button type="button" onClick={handleClick}>

--- a/src/components/atoms/IngredientListItem/IngredientListItem.tsx
+++ b/src/components/atoms/IngredientListItem/IngredientListItem.tsx
@@ -31,8 +31,8 @@ export const IngredientListItem = ({
   return (
     <li className="flex h-[49px] max-w-[480px] items-center justify-between px-4 py-2">
       <div>
-        <h3 className="text-fs14 leading-[17px] text-Mauve-12">{name}</h3>
-        {description && <p className=" text-xs mt-1 text-Mauve-10">{description}</p>}
+        <h3 className="text-sm text-Mauve-12">{name}</h3>
+        {description && <p className=" mt-1 text-xs text-Mauve-10">{description}</p>}
       </div>
       {isUseCartButton && (
         <button type="button" onClick={handleClick}>

--- a/src/components/atoms/RecipePreviewCard/RecipePreviewCard.tsx
+++ b/src/components/atoms/RecipePreviewCard/RecipePreviewCard.tsx
@@ -24,8 +24,8 @@ export const RecipePreviewCard = ({ index, imagePath, previewTitle, previewConte
   return (
     <div className={`w-[${PIC_SIZE[size]}px] h-[${H_SIZE[size]}px]`}>
       <Image width={PIC_SIZE[size]} height={PIC_SIZE[size]} src={imagePath} alt={`レシピ画像${index}`}></Image>
-      <p className="my-2 line-clamp-2 text-fs12 font-bold leading-3 text-Mauve-12">{previewTitle}</p>
-      <p className="text-xs line-clamp-1 font-normal text-Mauve-11">{previewContent}</p>
+      <p className="my-2 line-clamp-2 text-xs font-bold text-Mauve-12">{previewTitle}</p>
+      <p className="line-clamp-1 text-xs font-normal text-Mauve-11">{previewContent}</p>
     </div>
   )
 }

--- a/src/components/atoms/RecipePreviewCard/RecipePreviewCard.tsx
+++ b/src/components/atoms/RecipePreviewCard/RecipePreviewCard.tsx
@@ -25,7 +25,7 @@ export const RecipePreviewCard = ({ index, imagePath, previewTitle, previewConte
     <div className={`w-[${PIC_SIZE[size]}px] h-[${H_SIZE[size]}px]`}>
       <Image width={PIC_SIZE[size]} height={PIC_SIZE[size]} src={imagePath} alt={`レシピ画像${index}`}></Image>
       <p className="my-2 line-clamp-2 text-fs12 font-bold leading-3 text-Mauve-12">{previewTitle}</p>
-      <p className="line-clamp-1 text-fs10 font-normal leading-[10px] text-Mauve-11">{previewContent}</p>
+      <p className="text-xs line-clamp-1 font-normal text-Mauve-11">{previewContent}</p>
     </div>
   )
 }

--- a/src/components/atoms/RecipeStepItem/RecipeStepItem.tsx
+++ b/src/components/atoms/RecipeStepItem/RecipeStepItem.tsx
@@ -7,12 +7,12 @@ export interface RecipeStepItemProps {
 export const RecipeStepItem = ({ index, title, description }: RecipeStepItemProps) => {
   return (
     <li className="box-border flex max-w-[480px] list-none border-0 border-b-[1px] border-solid border-Mauve-07 px-4 py-2">
-      <p className="my-0 h-[18px] w-[18px] rounded-full bg-Tomato-11 text-center text-fs12 leading-[18px] text-Mauve-01">
+      <p className="text-fs12 my-0 h-[18px] w-[18px] rounded-full bg-Tomato-11 text-center leading-[18px] text-Mauve-01">
         {index}
       </p>
       <div className="ml-2 flex-1">
-        <h3 className="my-0 text-fs14 leading-[18px] text-Mauve-12">{title}</h3>
-        <p className="mb-0 mt-1 text-fs10 leading-4 text-Mauve-10">{description}</p>
+        <h3 className="text-fs14 my-0 leading-[18px] text-Mauve-12">{title}</h3>
+        <p className="mb-0 mt-1 text-xs text-Mauve-10">{description}</p>
       </div>
     </li>
   )

--- a/src/components/atoms/RecipeStepItem/RecipeStepItem.tsx
+++ b/src/components/atoms/RecipeStepItem/RecipeStepItem.tsx
@@ -7,7 +7,7 @@ export interface RecipeStepItemProps {
 export const RecipeStepItem = ({ index, title, description }: RecipeStepItemProps) => {
   return (
     <li className="box-border flex max-w-[480px] list-none border-0 border-b-[1px] border-solid border-Mauve-07 px-4 py-2">
-      <p className="text-fs12 my-0 h-[18px] w-[18px] rounded-full bg-Tomato-11 text-center leading-[18px] text-Mauve-01">
+      <p className="my-0 h-[18px] w-[18px] rounded-full bg-Tomato-11 text-center text-xs leading-[18px] text-Mauve-01">
         {index}
       </p>
       <div className="ml-2 flex-1">

--- a/src/components/atoms/RecipeStepItem/RecipeStepItem.tsx
+++ b/src/components/atoms/RecipeStepItem/RecipeStepItem.tsx
@@ -7,11 +7,9 @@ export interface RecipeStepItemProps {
 export const RecipeStepItem = ({ index, title, description }: RecipeStepItemProps) => {
   return (
     <li className="box-border flex max-w-[480px] list-none border-0 border-b-[1px] border-solid border-Mauve-07 px-4 py-2">
-      <p className="my-0 h-[18px] w-[18px] rounded-full bg-Tomato-11 text-center text-xs leading-[18px] text-Mauve-01">
-        {index}
-      </p>
+      <p className="my-0 h-[20px] w-[20px] rounded-full bg-Tomato-11 text-center text-sm text-Mauve-01">{index}</p>
       <div className="ml-2 flex-1">
-        <h3 className="text-fs14 my-0 leading-[18px] text-Mauve-12">{title}</h3>
+        <h3 className="my-0 text-sm text-Mauve-12">{title}</h3>
         <p className="mb-0 mt-1 text-xs text-Mauve-10">{description}</p>
       </div>
     </li>

--- a/src/components/atoms/ShoppingListItem/ShoppingListItem.tsx
+++ b/src/components/atoms/ShoppingListItem/ShoppingListItem.tsx
@@ -39,13 +39,13 @@ export const ShoppingListItem = ({
       <Checkbox color="cyan" radius="lg" styles={styles.checkbox} checked={isChecked} onChange={toggleCheck} />
       <input
         type="text"
-        className={`text-fs14 ${checkboxTextColor}`}
+        className={`text-sm ${checkboxTextColor}`}
         value={itemName}
         onChange={handleNameChange}
         readOnly={!isEditing}
       />
       {isShowDeleteButton && (
-        <button type="button" className="text-fs14 text-Tomato-09" onClick={onDelete}>
+        <button type="button" className="text-sm text-Tomato-09" onClick={onDelete}>
           削除
         </button>
       )}

--- a/src/components/atoms/buttons/AddButton/AddButton.tsx
+++ b/src/components/atoms/buttons/AddButton/AddButton.tsx
@@ -7,7 +7,7 @@ interface AddButtonProps {
 
 export const AddButton = ({ innerText, onClick }: AddButtonProps) => {
   return (
-    <button type="button" className="flex items-center text-fs16 leading-[19px] text-Tomato-12" onClick={onClick}>
+    <button type="button" className="flex items-center text-base text-Tomato-12" onClick={onClick}>
       <Image className="mr-1" src="assets/icons/add.svg" width={16} height={16} alt="addIcon" />
       {innerText}
       を追加する

--- a/src/components/atoms/buttons/CopyButton/CopyButton.tsx
+++ b/src/components/atoms/buttons/CopyButton/CopyButton.tsx
@@ -8,7 +8,7 @@ export const CopyButton = ({ onClick }: Props) => {
   return (
     <button className="ml-auto mr-0 flex items-center px-4 py-2" onClick={onClick}>
       <Image className="mr-[2px]" src="assets/icons/copy.svg" alt="copyIcon" width={18} height={18} />
-      <span className="text-fs12 leading-none text-Blue-alpha-11">コピーする</span>
+      <span className="text-xs text-Blue-alpha-11">コピーする</span>
     </button>
   )
 }

--- a/src/components/atoms/buttons/FloatingButton/FloatingButton.tsx
+++ b/src/components/atoms/buttons/FloatingButton/FloatingButton.tsx
@@ -13,7 +13,7 @@ interface FloatingButtonProps {
 export const FloatingButton = ({ onClick }: FloatingButtonProps) => {
   return (
     <button
-      className="fixed bottom-6 left-1/2 h-[48px] w-[200px] -translate-x-1/2 rounded-full bg-Tomato-09 text-fs16 font-bold text-Mauve-01 shadow-md"
+      className="fixed bottom-6 left-1/2 h-[48px] w-[200px] -translate-x-1/2 rounded-full bg-Tomato-09 text-base font-bold text-Mauve-01 shadow-md"
       onClick={onClick}
     >
       マイレシピを追加する

--- a/src/components/atoms/buttons/FollowOrFavoriteButton/FollowOrFavoriteButton.tsx
+++ b/src/components/atoms/buttons/FollowOrFavoriteButton/FollowOrFavoriteButton.tsx
@@ -25,7 +25,7 @@ export const FollowOrFavoriteButton = ({
 
   return (
     <button
-      className={`h-[25px] rounded px-3 text-fs14
+      className={`h-[25px] rounded px-3 text-sm
         ${isActive && "bg-Tomato-09 text-Mauve-01"}
         ${!isActive && "border-[1px] border-solid border-Tomato-07 text-Tomato-11"}
       `}

--- a/src/components/atoms/buttons/SaveButton/SaveButton.tsx
+++ b/src/components/atoms/buttons/SaveButton/SaveButton.tsx
@@ -7,7 +7,7 @@ interface SaveButtonProps {
 export const SaveButton = ({ innerText, onClick, type }: SaveButtonProps) => {
   return (
     <button
-      className={`h-[35px] w-[171px] rounded text-fs16
+      className={`h-[35px] w-[171px] rounded text-base
         ${type === "primary" && "bg-Tomato-09 text-Mauve-01"}
         ${type === "secondary" && "border-[1px] border-solid border-Tomato-07 text-Tomato-11"}
       `}

--- a/src/components/atoms/buttons/SocialLoginButton/SocialLoginButton.tsx
+++ b/src/components/atoms/buttons/SocialLoginButton/SocialLoginButton.tsx
@@ -9,7 +9,7 @@ export const SocialLoginButton = ({ platform = "google", onClick }: SocialLoginB
   return (
     <button
       type="button"
-      className={`flex cursor-pointer items-center rounded px-3 py-2 text-fs14 font-bold text-White
+      className={`flex cursor-pointer items-center rounded px-3 py-2 text-sm font-bold text-White
       ${platform === "google" && "bg-Blue-light-10"}
       ${platform === "apple" && "bg-Mauve-12"}
       `}

--- a/src/components/atoms/buttons/TextButton/TextButton.tsx
+++ b/src/components/atoms/buttons/TextButton/TextButton.tsx
@@ -15,7 +15,7 @@ export const TextButton = ({ innerText, onClick, disabled = false, primary = tru
 
   return (
     <button
-      className={["mx-[8px]  my-0 font-sans text-fs16 font-bold", textColor, className, disabled && "opacity-20"].join(
+      className={["mx-[8px] my-0 font-sans text-base font-bold", textColor, className, disabled && "opacity-20"].join(
         " ",
       )}
       onClick={onClick}

--- a/src/components/molecules/IngredientList/IngredientList.tsx
+++ b/src/components/molecules/IngredientList/IngredientList.tsx
@@ -47,7 +47,7 @@ export const IngredientList = ({ servingOfNumber }: Props) => {
   return (
     <div className="max-w-[480px]">
       <div className="flex h-[52px] items-center justify-between px-4 pb-2 pt-5">
-        <h3 className="text-fs20 font-bold leading-none text-Mauve-12">{servingOfNumber}人前</h3>
+        <h3 className="text-xl font-bold text-Mauve-12">{servingOfNumber}人前</h3>
         <button className="flex items-center font-bold" onClick={handleClickAddAll}>
           <Image className="mr-[2px]" src="assets/icons/cart_gray.svg" alt="cartIcon" width={18} height={18} />
           <span className="text-base font-bold text-Mauve-09">まとめてお買い物に追加</span>

--- a/src/components/molecules/IngredientList/IngredientList.tsx
+++ b/src/components/molecules/IngredientList/IngredientList.tsx
@@ -50,7 +50,7 @@ export const IngredientList = ({ servingOfNumber }: Props) => {
         <h3 className="text-fs20 font-bold leading-none text-Mauve-12">{servingOfNumber}人前</h3>
         <button className="flex items-center font-bold" onClick={handleClickAddAll}>
           <Image className="mr-[2px]" src="assets/icons/cart_gray.svg" alt="cartIcon" width={18} height={18} />
-          <span className="text-fs16 font-bold leading-none text-Mauve-09">まとめてお買い物に追加</span>
+          <span className="text-base font-bold text-Mauve-09">まとめてお買い物に追加</span>
         </button>
       </div>
       <ul className="divide-y divide-Mauve-07 border border-l-0 border-r-0 border-Mauve-07">

--- a/src/components/molecules/headers/HeaderWithBackButton/HeaderWithBackButton.tsx
+++ b/src/components/molecules/headers/HeaderWithBackButton/HeaderWithBackButton.tsx
@@ -13,7 +13,7 @@ const HeaderWithBackButton = ({ title, isUseBackButton }: HeaderWithBackButtonPr
   return (
     <header className="relative flex h-12 max-w-[480px] items-center justify-center border-0 border-b-[1px] border-solid border-Mauve-06 ">
       {isUseBackButton && <BackButton color="black" className="absolute left-4 top-3" />}
-      <h1 className="text-fs20 font-bold leading-6 text-Mauve-12">{title}</h1>
+      <h1 className="text-xl font-bold text-Mauve-12">{title}</h1>
     </header>
   )
 }

--- a/src/components/organisms/Tab.tsx
+++ b/src/components/organisms/Tab.tsx
@@ -17,7 +17,7 @@ export const Tab = ({ tabItems }: TabProps) => {
             <li className="w-full" key={`item${index + 1}`}>
               <button
                 className={[
-                  "h-10 w-full text-center text-fs16 font-bold text-Mauve-12",
+                  "h-10 w-full text-center text-base font-bold text-Mauve-12",
                   activeTab === `item${index + 1}` && "border-0 border-b-2 border-Mauve-12",
                 ].join(" ")}
                 onClick={() => setActiveTab(`item${index + 1}`)}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -35,14 +35,6 @@ module.exports = {
       "Blue-alpha-11": "#0066DB", // Blue/Light Alpha/11
       "Blue-light-10": "#0081F1", // Blue/Light/10
     },
-    fontSize: {
-      fs10: "10px",
-      fs12: "12px",
-      fs14: "14px",
-      fs16: "16px",
-      fs20: "20px",
-      fs24: "24px",
-    },
   },
   plugins: [],
   corePlugins: {


### PR DESCRIPTION
## タスク URL

なし

# 作業内容
Figmaのデザイン通りにしなくて良い（各チームよしなになってくれ）というお話だったので、
font-size周りを`text-fs16  leading-[19px]`みたいに書いていたところ簡略化しました。
```
fs10: "10px" → text-xs
fs12: "12px" → text-xs
fs14: "14px" → text-sm
fs16: "16px" → text-base
fs18: "18px" → text-lg （今のところなし）
fs20: "20px" → text-xl
fs24: "24px" → text-2xl（今のところなし）
```

（※ font-size10pxは小さすぎて読みにくいため12pxとする）

## 作業内容補足（任意）
他コンポーネントと組み合わせていったときにデザイン上違和感がある箇所は解消していきましょう！