### PR TITLE
【UI】atoms/SectionTitle の作成

### DIFF
--- a/src/components/atoms/SectionTitle/SectionTitle.stories.ts
+++ b/src/components/atoms/SectionTitle/SectionTitle.stories.ts
@@ -1,0 +1,34 @@
+import { FONT_SIZE, HEADING, SectionTitle } from "./SectionTitle"
+
+import type { Meta, StoryObj } from "@storybook/react"
+
+const meta: Meta<typeof SectionTitle> = {
+  title: "Atoms/SectionTitle",
+  component: SectionTitle,
+  tags: ["autodocs"],
+}
+
+export default meta
+type Story = StoryObj<typeof SectionTitle>
+
+export const size_2xl: Story = {
+  args: {
+    fontSize: FONT_SIZE.XXL,
+    heading: HEADING.H1,
+    text: "シェフの名前（24px）",
+  },
+}
+export const size_xl: Story = {
+  args: {
+    fontSize: FONT_SIZE.XL,
+    heading: HEADING.H2,
+    text: "注目のシェフ（20px）",
+  },
+}
+export const size_lg: Story = {
+  args: {
+    fontSize: FONT_SIZE.LG,
+    heading: HEADING.H3,
+    text: "しまぶーシェフ（18px）",
+  },
+}

--- a/src/components/atoms/SectionTitle/SectionTitle.tsx
+++ b/src/components/atoms/SectionTitle/SectionTitle.tsx
@@ -1,0 +1,38 @@
+export const FONT_SIZE = {
+  XXL: "2xl",
+  XL: "xl",
+  LG: "lg",
+} as const
+
+type FontSizeType = typeof FONT_SIZE
+
+export const HEADING = {
+  H1: "h1",
+  H2: "h2",
+  H3: "h3",
+  H4: "h4",
+} as const
+
+type HeadingType = typeof HEADING
+
+export interface SectionTitleProps {
+  fontSize: FontSizeType[keyof FontSizeType]
+  heading: HeadingType[keyof HeadingType]
+  text: string
+}
+
+export const SectionTitle = ({ heading, text, fontSize }: SectionTitleProps) => {
+  switch (heading) {
+    case HEADING.H1:
+      return <h1 className={`font-bold text-${fontSize}`}>{text}</h1>
+
+    case HEADING.H2:
+      return <h2 className={`font-bold text-${fontSize}`}>{text}</h2>
+
+    case HEADING.H3:
+      return <h3 className={`font-bold text-${fontSize}`}>{text}</h3>
+
+    case HEADING.H4:
+      return <h4 className={`font-bold text-${fontSize}`}>{text}</h4>
+  }
+}


### PR DESCRIPTION
## タスク URL

なし

<img width="787" alt="スクリーンショット 2023-07-18 22 26 13" src="https://github.com/qin-team-recipe/07-recipe-app-front/assets/67771199/b9a3f7b1-adfe-461c-a3bf-9275a9ddbb12">
水色枠のようなセクションのタイトルなど

# 作業内容

- atoms/SectionTitle の作成

## 作業内容補足（任意）

色々な箇所で使えるように汎用化したけど、うーんという気持ちです。作らなくても良かったのかも・・・