### PR TITLE
シェフ写真のpathの遷移先を変更

### DIFF
--- a/src/components/molecules/MyPageDetail/MyPageDetail.tsx
+++ b/src/components/molecules/MyPageDetail/MyPageDetail.tsx
@@ -23,7 +23,7 @@ export const MyPageDetail = (props: MyPageDetailProps) => {
           <p className="mb-3 text-sm  text-Mauve-12">{props.id}</p>
         </div>
         <div className="float-right flex">
-          <CircleChef icon={props.image} name={""} url={"/"} />
+          <CircleChef icon={props.image} name={""} url={props.url} />
         </div>
       </div>
       <div>


### PR DESCRIPTION
## タスク URL

タスクの URL を GitHubProject からコピーしてペースト
https://github.com/qin-team-recipe/07-recipe-app-front/compare/feature/fix/components/molecules/MyPageDetail?expand=1
# 作業内容

- このプルリクエストにて何をしたのか？
シェフアイコンのpathを修正
## 作業内容補足（任意）

- 作業内容の補足説明があればここに記載
