### PR TITLE
アイコンの名前変更による修正

### DIFF
--- a/src/components/atoms/buttons/CopyButton/CopyButton.tsx
+++ b/src/components/atoms/buttons/CopyButton/CopyButton.tsx
@@ -7,7 +7,7 @@ type Props = {
 export const CopyButton = ({ onClick }: Props) => {
   return (
     <button className="ml-auto mr-0 flex items-center px-4 py-2" onClick={onClick}>
-      <Image className="mr-[2px]" src="assets/icons/copy.svg" alt="copyIcon" width={18} height={18} />
+      <Image className="mr-[2px]" src="assets/icons/copy_blue.svg" alt="copyIcon" width={18} height={18} />
       <span className="text-xs text-Blue-alpha-11">コピーする</span>
     </button>
   )


### PR DESCRIPTION
## タスク URL

タスクの URL を GitHubProject からコピーしてペースト
https://github.com/qin-team-recipe/07-recipe-app-front/compare/develop...feature/fix/atoms/buttons/CopyButton?expand=1
# 作業内容

- このプルリクエストにて何をしたのか？
コピーボタンアイコン名変更に伴って修正
## 作業内容補足（任意）

- 作業内容の補足説明があればここに記載
（グレーのコピーボタンも必要となったため、こちらの仕様はブルーボタンのため修正）