### PR TITLE
LinkのpathをRecipeDetailsPageに修正

### DIFF
--- a/src/components/atoms/buttons/FloatingButton/FloatingButton.tsx
+++ b/src/components/atoms/buttons/FloatingButton/FloatingButton.tsx
@@ -6,6 +6,8 @@
  * propsは受け取らないように実装し直しても良さそう
  */
 
+import Link from "next/link"
+
 interface FloatingButtonProps {
   onClick: () => void
 }
@@ -16,7 +18,7 @@ export const FloatingButton = ({ onClick }: FloatingButtonProps) => {
       className="fixed bottom-6 left-1/2 h-[48px] w-[200px] -translate-x-1/2 rounded-full bg-Tomato-09 text-base font-bold text-Mauve-01 shadow-md"
       onClick={onClick}
     >
-      マイレシピを追加する
+      <Link href={"/RecipeDetailsPage"}>マイレシピを追加する</Link>
     </button>
   )
 }


### PR DESCRIPTION
## タスク URL

タスクの URL を GitHubProject からコピーしてペースト
https://github.com/qin-team-recipe/07-recipe-app-front/compare/develop...feature/fix/components/atoms/FloatingButton?expand=1
# 作業内容

- このプルリクエストにて何をしたのか？
Linkの遷移先を追加
## 作業内容補足（任意）

- 作業内容の補足説明があればここに記載
